### PR TITLE
Add min_p sampling from logits

### DIFF
--- a/docs/api/sampling.rst
+++ b/docs/api/sampling.rst
@@ -14,6 +14,7 @@ Kernels for LLM sampling.
     top_p_sampling_from_probs
     top_k_sampling_from_probs
     min_p_sampling_from_probs
+    min_p_sampling_from_logits
     top_k_top_p_sampling_from_logits
     top_k_top_p_sampling_from_probs
     top_p_renorm_probs

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -86,6 +86,7 @@ from .rope import (
 )
 from .sampling import chain_speculative_sampling as chain_speculative_sampling
 from .sampling import min_p_sampling_from_probs as min_p_sampling_from_probs
+from .sampling import min_p_sampling_from_logits as min_p_sampling_from_logits
 from .sampling import sampling_from_logits as sampling_from_logits
 from .sampling import sampling_from_probs as sampling_from_probs
 from .sampling import top_k_mask_logits as top_k_mask_logits

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from types import SimpleNamespace
 from typing import Optional, Union
+import math
 
 import torch
 
@@ -802,6 +803,80 @@ def min_p_sampling_from_probs(
             raise ValueError("Input probs contains NaN.")
     return get_sampling_module().min_p_sampling_from_probs(
         probs, indices, *_to_tensor_scalar_tuple(min_p), deterministic, generator
+    )
+
+
+def min_p_sampling_from_logits(
+    logits: torch.Tensor,
+    min_p: Union[torch.Tensor, float],
+    indices: Optional[torch.Tensor] = None,
+    deterministic: bool = True,
+    generator: Optional[torch.Generator] = None,
+    check_nan: bool = False,
+) -> torch.Tensor:
+    """Sample from logits using ``min_p`` filtering with the Gumbel-Max trick.
+
+    This function is equivalent to applying ``min_p_sampling_from_probs`` to
+    ``softmax(logits)`` but avoids explicit probability computation by masking
+    logits and reusing :func:`sampling_from_logits`.
+
+    Parameters
+    ----------
+    logits: torch.Tensor
+        Logits for sampling. When ``indices`` is not provided the shape should
+        be ``(batch_size, num_classes)``. When ``indices`` is provided the shape
+        should be ``(unique_batch_size, num_classes)`` where
+        ``unique_batch_size`` is the number of unique probability distributions.
+    min_p: Union[torch.Tensor, float]
+        Either a scalar or a tensor of shape ``(batch_size,)`` representing the
+        ``min_p`` threshold. If a tensor, each request has its own threshold.
+    indices: Optional[torch.Tensor]
+        Optional indices tensor of shape ``(batch_size,)`` that maps each output
+        to a row in ``logits``.
+    deterministic: bool
+        Whether to use deterministic kernel implementation. This argument is kept
+        for compatibility with other sampling functions.
+    generator: Optional[torch.Generator]
+        Random number generator for sampling.
+    check_nan: bool
+        Whether to check ``logits`` for ``NaN`` values.
+
+    Returns
+    -------
+    samples: torch.Tensor
+        Sampled categories with shape ``(batch_size,)``.
+    """
+
+    if check_nan:
+        if torch.any(torch.isnan(logits)):
+            raise ValueError("Input logits contains NaN.")
+
+    device = logits.device
+    if indices is not None:
+        gathered_logits = logits.index_select(0, indices)
+    else:
+        gathered_logits = logits
+
+    gathered_logits = gathered_logits.float()
+
+    if isinstance(min_p, torch.Tensor):
+        log_p = torch.log(min_p.float()).unsqueeze(-1)
+    else:
+        log_p = math.log(float(min_p))
+
+    max_logits = gathered_logits.max(dim=-1, keepdim=True).values
+    pivot = max_logits + log_p
+
+    masked_logits = torch.where(
+        gathered_logits >= pivot,
+        gathered_logits,
+        torch.tensor(-float("inf"), device=device),
+    )
+
+    return sampling_from_logits(
+        masked_logits,
+        deterministic=deterministic,
+        generator=generator,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ TORCH_COMPILE_FNS = [
     flashinfer.sampling.top_p_sampling_from_probs,
     flashinfer.sampling.top_k_sampling_from_probs,
     flashinfer.sampling.min_p_sampling_from_probs,
+    flashinfer.sampling.min_p_sampling_from_logits,
     flashinfer.sampling.top_k_top_p_sampling_from_probs,
     flashinfer.sampling.top_p_renorm_probs,
     flashinfer.sampling.top_k_renorm_probs,

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -258,6 +258,27 @@ def test_min_p_sampling(batch_size, vocab_size, p):
 
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
+@pytest.mark.parametrize("p", [0.05, 0.1, 0.2, 0.7, 1])
+def test_min_p_sampling_from_logits(batch_size, vocab_size, p):
+    torch.manual_seed(42)
+    logits = torch.randn(batch_size, vocab_size, device="cuda:0") * 5
+    probs = torch.softmax(logits, dim=-1)
+    sorted_prob, indices = torch.sort(probs, descending=False)
+    top_probs = sorted_prob[:, -1].unsqueeze(-1)
+    scaled_p = p * top_probs
+    mask = torch.zeros(batch_size, vocab_size, dtype=torch.int32, device="cuda:0")
+    mask.scatter_add_(1, indices, (sorted_prob >= scaled_p).int())
+    min_p_tensor = torch.full((batch_size,), p, device="cuda:0")
+
+    num_trails = 1000
+    for _ in range(num_trails):
+        samples = flashinfer.sampling.min_p_sampling_from_logits(logits, min_p_tensor)
+
+        assert torch.all(mask[torch.arange(batch_size), samples] == 1)
+
+
+@pytest.mark.parametrize("batch_size", [1, 99, 989])
+@pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.1, 0.5])
 def test_top_k_top_p_joint_sampling_from_probs(batch_size, vocab_size, p):
     torch.manual_seed(42)


### PR DESCRIPTION
## Summary
- implement `min_p_sampling_from_logits` using gumbel max masking
- export new API
- document and test new function
- support torch compile in tests

## Testing
- `bash format.sh` *(fails: Could not find a version that satisfies the requirement yapf==0.40.2)*
- `pytest -k min_p_sampling_from_logits -q` *(fails: ModuleNotFoundError: No module named 'torch')*